### PR TITLE
Change link to contribution guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Here's some interfaces you could implement for common use cases:
 - **IResolverIgnoreRule** - Allows you to define subpaths that are ignored by media resolvers for use with another function (i.e. you wanted to have a theme song for each tv series stored in a subfolder that could be accessed by your plugin for playback in a menu).
 - **IScheduledTask** - Allows you to create a scheduled task that will appear in the scheduled task lists on the dashboard.
 	
-There are loads of other interfaces that can be used, but you'll need to poke around the API to get some info. If you're an expert on a particular interface, you should help [contribute some documentation](https://jellyfin.org/docs/)!
+There are loads of other interfaces that can be used, but you'll need to poke around the API to get some info. If you're an expert on a particular interface, you should help [contribute some documentation](https://jellyfin.org/docs/general/contributing/index.html)!
 
 ### 4b. Use plugin aimed interfaces to add custom functionality
 


### PR DESCRIPTION
Changes the link to the docs to be the contribution guide, as that will be the best starting point.