### PR TITLE
chore(ci): add missed out --no-restore

### DIFF
--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -21,7 +21,7 @@ jobs:
         run: dotnet restore
 
       - name: "Build"
-        run: dotnet build --configuration Release
+        run: dotnet build --configuration Release --no-restore
 
       - name: "Test"
         run: dotnet test --no-restore --verbosity normal


### PR DESCRIPTION
while working on the ci PRs for the other plugins I noticed that `--no-restore` was missing, so this PR now also adds it to the plugin template