### PR TITLE
Target Jellyfin 10.8

### DIFF
--- a/Jellyfin.Plugin.Template/Jellyfin.Plugin.Template.csproj
+++ b/Jellyfin.Plugin.Template/Jellyfin.Plugin.Template.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
-    <PackageReference Include="Jellyfin.Model" Version="10.*-*" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.8.0" />
+    <PackageReference Include="Jellyfin.Model" Version="10.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/build.yaml
+++ b/build.yaml
@@ -2,8 +2,8 @@
 name: "Template"
 guid: "eb5d7894-8eef-4b36-aa6f-5d124e828ce1"
 version: "1.0.0.0"
-targetAbi: "10.7.0.0"
-framework: "net5.0"
+targetAbi: "10.8.0.0"
+framework: "net6.0"
 overview: "Short description about your plugin"
 description: >
   This is a longer description that can span more than one


### PR DESCRIPTION
JPRM CI broke cause of the 10.8 update and the switch to .net6, due to the project targeting whatever the latest version is, and there being a miss-match between the .net version