### PR TITLE
Add support for Linux to the development setup for Visual Studio Code

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,11 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+    // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+    // List of extensions which should be recommended for users of this workspace.
+    "recommendations": [
+        "ms-dotnettools.csharp",
+        "editorconfig.editorconfig"
+    ],
+    // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+    "unwantedRecommendations": []
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,15 +1,19 @@
 {
     // jellyfinDir : The directory of the cloned jellyfin server project
     // This needs to be built once before it can be used
-    "jellyfinDir"     : "${workspaceFolder}/../jellyfin/Jellyfin.Server",
+    "jellyfinDir": "${workspaceFolder}/../jellyfin/Jellyfin.Server",
     // jellyfinWebDir : The directory of the cloned jellyfin-web project
     // This needs to be built once before it can be used
-    "jellyfinWebDir"  : "${workspaceFolder}/../jellyfin-web",
+    "jellyfinWebDir": "${workspaceFolder}/../jellyfin-web",
     // jellyfinDataDir : the root data directory for a running jellyfin instance
     // This is where jellyfin stores its configs, plugins, metadata etc
     // This is platform specific by default, but on Windows defaults to
     // ${env:LOCALAPPDATA}/jellyfin
-    "jellyfinDataDir" : "${env:LOCALAPPDATA}/jellyfin",
+    // and on Linux, it defaults to
+    // ${env:XDG_DATA_HOME}/jellyfin
+    // However ${env:XDG_DATA_HOME} does not work in Visual Studio Code's development container!
+    "jellyfinWindowsDataDir": "${env:LOCALAPPDATA}/jellyfin",
+    "jellyfinLinuxDataDir": "$HOME/.local/share/jellyfin",
     // The name of the plugin
-    "pluginName" : "Jellyfin.Plugin.Template",
+    "pluginName": "Jellyfin.Plugin.Template",
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,7 +7,11 @@
       // jellyfin server's plugin directory
       "label": "build-and-copy",
       "dependsOrder": "sequence",
-      "dependsOn": ["build", "make-plugin-dir", "copy-dll"]
+      "dependsOn": [
+        "build",
+        "make-plugin-dir",
+        "copy-dll"
+      ]
     },
     {
       // Build the plugin
@@ -27,29 +31,45 @@
       "problemMatcher": "$msCompile"
     },
     {
-        // Ensure the plugin directory exists before trying to use it
-        "label": "make-plugin-dir",
-        "type": "shell",
-        "command": "mkdir",
+      // Ensure the plugin directory exists before trying to use it
+      "label": "make-plugin-dir",
+      "type": "shell",
+      "command": "mkdir",
+      "windows": {
         "args": [
-           "-Force",
-           "-Path",
-           "${config:jellyfinDataDir}/plugins/${config:pluginName}/"
+          "-Force",
+          "-Path",
+          "${config:jellyfinWindowsDataDir}/plugins/${config:pluginName}/"
         ]
+      },
+      "linux": {
+        "args": [
+          "-p",
+          "${config:jellyfinLinuxDataDir}/plugins/${config:pluginName}/"
+        ]
+      }
     },
     {
-        // Copy the plugin dll to the jellyfin plugin install path
-        // This command copies every .dll from the build directory to the plugin dir
-        // Usually, you probablly only need ${config:pluginName}.dll
-        // But some plugins may bundle extra requirements
-        "label": "copy-dll",
-        "type": "shell",
-        "command": "cp",
+      // Copy the plugin dll to the jellyfin plugin install path
+      // This command copies every .dll from the build directory to the plugin dir
+      // Usually, you probablly only need ${config:pluginName}.dll
+      // But some plugins may bundle extra requirements
+      "label": "copy-dll",
+      "type": "shell",
+      "command": "cp",
+      "windows": {
         "args": [
-           "./${config:pluginName}/bin/Debug/net6.0/publish/*",
-           "${config:jellyfinDataDir}/plugins/${config:pluginName}/"
+          "./${config:pluginName}/bin/Debug/net6.0/publish/*",
+          "${config:jellyfinWindowsDataDir}/plugins/${config:pluginName}/"
         ]
-
+      },
+      "linux": {
+        "args": [
+          "-r",
+          "./${config:pluginName}/bin/Debug/net6.0/publish/*",
+          "${config:jellyfinLinuxDataDir}/plugins/${config:pluginName}/"
+        ]
+      }
     },
   ]
 }


### PR DESCRIPTION
**What this PR does?:**
Adds support for linux to the development setup of Visual Studio Code as it's currently windows only (as described in #49).

It seems like it's not possible to add platform specific data to the _.vscode/settings.json_ unless every user installs additional extensions, thus I copied the variables and renamed them to make clear which variable is for which platform.