### PR TITLE
README.md: Fix sh UUID generator and make call to head POSIX-compliant

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ You need to populate some of your plugin's information. Go ahead a put in a stri
 - **Linux and OS X Users**: you can use the Powershell Core command `New-Guid` or this command from your shell of choice:
 
    ```bash
-   od -x /dev/urandom | head -1 | awk '{OFS="-"; srand($6); sub(/./,"4",$5); sub(/./,substr("89ab",rand()*4,1),$6); print $2$3,$4,$5,$6,$7$8$9}'
+   od -x /dev/urandom | head -n1 | awk '{OFS="-"; srand($6); sub(/./,"4",$5); sub(/./,substr("89ab",1+rand()*4,1),$6); print $2$3,$4,$5,$6,$7$8$9}'
    ```
 
 or


### PR DESCRIPTION
In awk, substr starts its indexing at 1, so the fourth word of the UUIDs generated before would never start with "b" and would start with "8" twice as often as any other character.

Also, even though I can't find an implementation of head that errors with `-1`, `-n1` is the POSIX-compliant way and it's a harmless change in any case.