### PR TITLE
Replace obsolete reference to IServerEntryPoint and update to .net 8

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
             "name": "Launch",
             "request": "launch",
             "preLaunchTask": "build-and-copy",
-            "program": "${config:jellyfinDir}/bin/Debug/net6.0/jellyfin.dll",
+            "program": "${config:jellyfinDir}/bin/Debug/net8.0/jellyfin.dll",
             "args": [
                //"--nowebclient"
                "--webdir",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -46,7 +46,7 @@
         "type": "shell",
         "command": "cp",
         "args": [
-           "./${config:pluginName}/bin/Debug/net6.0/publish/*",
+           "./${config:pluginName}/bin/Debug/net8.0/publish/*",
            "${config:jellyfinDataDir}/plugins/${config:pluginName}/"
         ]
 

--- a/Jellyfin.Plugin.Template.sln
+++ b/Jellyfin.Plugin.Template.sln
@@ -1,15 +1,28 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jellyfin.Plugin.Template", "Jellyfin.Plugin.Template\Jellyfin.Plugin.Template.csproj", "{D921B930-CF91-406F-ACBC-08914DCD0D34}"
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
+# 
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jellyfin.Plugin.Template", "Jellyfin.Plugin.Template\Jellyfin.Plugin.Template.csproj", "{5575CBE2-835F-42AC-A237-F698120E18A3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{D921B930-CF91-406F-ACBC-08914DCD0D34}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D921B930-CF91-406F-ACBC-08914DCD0D34}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D921B930-CF91-406F-ACBC-08914DCD0D34}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D921B930-CF91-406F-ACBC-08914DCD0D34}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5575CBE2-835F-42AC-A237-F698120E18A3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5575CBE2-835F-42AC-A237-F698120E18A3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5575CBE2-835F-42AC-A237-F698120E18A3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5575CBE2-835F-42AC-A237-F698120E18A3}.Debug|x64.Build.0 = Debug|Any CPU
+		{5575CBE2-835F-42AC-A237-F698120E18A3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5575CBE2-835F-42AC-A237-F698120E18A3}.Debug|x86.Build.0 = Debug|Any CPU
+		{5575CBE2-835F-42AC-A237-F698120E18A3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5575CBE2-835F-42AC-A237-F698120E18A3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5575CBE2-835F-42AC-A237-F698120E18A3}.Release|x64.ActiveCfg = Release|Any CPU
+		{5575CBE2-835F-42AC-A237-F698120E18A3}.Release|x64.Build.0 = Release|Any CPU
+		{5575CBE2-835F-42AC-A237-F698120E18A3}.Release|x86.ActiveCfg = Release|Any CPU
+		{5575CBE2-835F-42AC-A237-F698120E18A3}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/Jellyfin.Plugin.Template/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Template/Configuration/PluginConfiguration.cs
@@ -1,57 +1,58 @@
 using MediaBrowser.Model.Plugins;
 
-namespace Jellyfin.Plugin.Template.Configuration;
-
-/// <summary>
-/// The configuration options.
-/// </summary>
-public enum SomeOptions
+namespace Jellyfin.Plugin.Template.Configuration
 {
     /// <summary>
-    /// Option one.
+    /// The configuration options.
     /// </summary>
-    OneOption,
-
-    /// <summary>
-    /// Second option.
-    /// </summary>
-    AnotherOption
-}
-
-/// <summary>
-/// Plugin configuration.
-/// </summary>
-public class PluginConfiguration : BasePluginConfiguration
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref="PluginConfiguration"/> class.
-    /// </summary>
-    public PluginConfiguration()
+    public enum SomeOptions
     {
-        // set default options here
-        Options = SomeOptions.AnotherOption;
-        TrueFalseSetting = true;
-        AnInteger = 2;
-        AString = "string";
+        /// <summary>
+        /// Option one.
+        /// </summary>
+        OneOption,
+
+        /// <summary>
+        /// Second option.
+        /// </summary>
+        AnotherOption
     }
 
     /// <summary>
-    /// Gets or sets a value indicating whether some true or false setting is enabled..
+    /// Plugin configuration.
     /// </summary>
-    public bool TrueFalseSetting { get; set; }
+    public class PluginConfiguration : BasePluginConfiguration
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PluginConfiguration"/> class.
+        /// </summary>
+        public PluginConfiguration()
+        {
+            // set default options here
+            Options = SomeOptions.AnotherOption;
+            TrueFalseSetting = true;
+            AnInteger = 2;
+            AString = "string";
+        }
 
-    /// <summary>
-    /// Gets or sets an integer setting.
-    /// </summary>
-    public int AnInteger { get; set; }
+        /// <summary>
+        /// Gets or sets a value indicating whether some true or false setting is enabled..
+        /// </summary>
+        public bool TrueFalseSetting { get; set; }
 
-    /// <summary>
-    /// Gets or sets a string setting.
-    /// </summary>
-    public string AString { get; set; }
+        /// <summary>
+        /// Gets or sets an integer setting.
+        /// </summary>
+        public int AnInteger { get; set; }
 
-    /// <summary>
-    /// Gets or sets an enum option.
-    /// </summary>
-    public SomeOptions Options { get; set; }
+        /// <summary>
+        /// Gets or sets a string setting.
+        /// </summary>
+        public string AString { get; set; }
+
+        /// <summary>
+        /// Gets or sets an enum option.
+        /// </summary>
+        public SomeOptions Options { get; set; }
+    }
 }

--- a/Jellyfin.Plugin.Template/Jellyfin.Plugin.Template.csproj
+++ b/Jellyfin.Plugin.Template/Jellyfin.Plugin.Template.csproj
@@ -1,29 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <RootNamespace>Jellyfin.Plugin.Template</RootNamespace>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
-    <CodeAnalysisRuleSet>../jellyfin.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.8.13" />
-    <PackageReference Include="Jellyfin.Model" Version="10.8.13" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="SerilogAnalyzer" Version="0.15.0" PrivateAssets="All" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507" PrivateAssets="All" />
-    <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Remove="Configuration\configPage.html" />
-    <EmbeddedResource Include="Configuration\configPage.html" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.9.1" />
+    <PackageReference Include="Jellyfin.Model" Version="10.9.1" />
   </ItemGroup>
 
 </Project>

--- a/Jellyfin.Plugin.Template/Plugin.cs
+++ b/Jellyfin.Plugin.Template/Plugin.cs
@@ -1,6 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Globalization;
+﻿using System.Globalization;
 using Jellyfin.Plugin.Template.Configuration;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Plugins;

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # So you want to make a Jellyfin plugin
 
-Awesome! This guide is for you. Jellyfin plugins are written using the dotnet standard framework. What that means is you can write them in any language that implements the CLI or the DLI and can compile to net6.0. The examples on this page are in C# because that is what most of Jellyfin is written in, but F#, Visual Basic, and IronPython should all be compatible once compiled.
+Awesome! This guide is for you. Jellyfin plugins are written using the dotnet standard framework. What that means is you can write them in any language that implements the CLI or the DLI and can compile to net8.0. The examples on this page are in C# because that is what most of Jellyfin is written in, but F#, Visual Basic, and IronPython should all be compatible once compiled.
 
 ## 0. Things you need to get started
 
-- [Dotnet SDK 6.0](https://dotnet.microsoft.com/download)
+- [Dotnet SDK 8.0](https://dotnet.microsoft.com/download)
 
 - An editor of your choice. Some free choices are:
 
@@ -39,7 +39,7 @@ If you'd rather start from scratch keep going on to step one. This assumes no sp
 Make a new dotnet standard project with the following command, it will make a directory for itself.
 
 ```
-dotnet new classlib -f net6.0 -n MyJellyfinPlugin
+dotnet new classlib -f net8.0 -n MyJellyfinPlugin
 ```
 
 Now add the Jellyfin shared libraries.
@@ -126,7 +126,15 @@ If your plugin doesn't fit perfectly neatly into a predefined interface, never f
 
 - **IPluginConfigurationPage** - Allows you to have a plugin config page on the dashboard. If you used one of the quickstart example projects, a premade page with some useful components to work with has been created for you! If not you can check out this guide here for how to whip one up.
 
-- **IServerEntryPoint** - Allows you to run code at server startup that will stay in memory. You can make as many of these as you need and it is wildly useful for loading configs or persisting state. **Be aware that your main plugin class (IBasePlugin) cannot also be a IServerEntryPoint.**
+- **IPluginServiceRegistrator** - Will be located by Jellyfin at server startup and
+allows you to add services to the DI container to allow for injection in your
+plugin's classes later.
+
+- **IHostedService** - Allows you to run code as a background task that will be
+started at program startup and will remain in memory. See
+[Microsoft's documentation](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/host/hosted-services?view=aspnetcore-8.0&tabs=visual-studio#ihostedservice-interface) for more information. You can make as
+ many of these as you need; make Jellyfin aware of them with an
+ `IPluginServiceRegistrator`. It is wildly useful for loading configs or persisting state. **Be aware that your main plugin class (IBasePlugin) cannot also be a IHostedService.**
 
 - **ControllerBase** - Allows you to define custom REST-API endpoints. This is the default ASP.NET Web-API controller. You can use it exactly as you would in a normal Web-API project. Learn more about it [here](https://docs.microsoft.com/aspnet/core/web-api/?view=aspnetcore-5.0).
 
@@ -220,7 +228,7 @@ This example expects you to clone `jellyfin`, `jellyfin-web` and `jellyfin-plugi
                 "name": "Launch",
                 "request": "launch",
                 "preLaunchTask": "build-and-copy",
-                "program": "${config:jellyfinDir}/bin/Debug/net6.0/jellyfin.dll",
+                "program": "${config:jellyfinDir}/bin/Debug/net8.0/jellyfin.dll",
                 "args": [
                 //"--nowebclient"
                 "--webdir",
@@ -288,7 +296,7 @@ This example expects you to clone `jellyfin`, `jellyfin-web` and `jellyfin-plugi
                 "type": "shell",
                 "command": "cp",
                 "args": [
-                "./${config:pluginName}/bin/Debug/net6.0/publish/*",
+                "./${config:pluginName}/bin/Debug/net8.0/publish/*",
                 "${config:jellyfinDataDir}/plugins/${config:pluginName}/"
                 ]
 
@@ -356,7 +364,7 @@ This example expects you to clone `jellyfin`, `jellyfin-web` and `jellyfin-plugi
                 "type": "shell",
                 "command": "cp",
                 "args": [
-                "./${config:pluginName}/bin/Debug/net6.0/publish/*",
+                "./${config:pluginName}/bin/Debug/net8.0/publish/*",
                 "${config:jellyfinDataDir}/plugins/${config:pluginName}/"
                 ]
             },

--- a/build.yaml
+++ b/build.yaml
@@ -3,7 +3,7 @@ name: "Template"
 guid: "eb5d7894-8eef-4b36-aa6f-5d124e828ce1"
 version: "1.0.0.0"
 targetAbi: "10.8.0.0"
-framework: "net6.0"
+framework: "net8.0"
 overview: "Short description about your plugin"
 description: >
   This is a longer description that can span more than one


### PR DESCRIPTION
Was planning to just remove IServerEntryPoint reference because that interface was removed from Jellyfin a few months ago, but saw issue #69 that also asked for the sample to use .net 8 and so if that's what the people want...

* Fixes #69 