### PR TITLE
Updated to specify that you need to place the plugin DLL into a subfolder

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ or
 
 ## 4. Adding Functionality
 
-Congratulations, you now have everything you need for a perfectly functional functionless Jellyfin plugin! You can try it out right now if you'd like by compiling it, then placing the dll you generate in the plugins folder under your Jellyfin config directory. If you want to try and hook it up to a debugger make sure you copy the generated PDB file alongside it.
+Congratulations, you now have everything you need for a perfectly functional functionless Jellyfin plugin! You can try it out right now if you'd like by compiling it, then placing the dll you generate in a subfolder (named after your plugin for example) within the plugins folder under your Jellyfin config directory. If you want to try and hook it up to a debugger make sure you copy the generated PDB file alongside it.
 
 Most people aren't satisfied with just having an entry in a menu for their plugin, most people want to have some functionality, so lets look at how to add it.
 


### PR DESCRIPTION
I was pulling my hair out for a long time before I realized Jellyfin (at least on ubuntu) will not load DLL files unless they are placed in a subfolder within the plugins folder. It was not a permissions issue either, I tried changing them and I also tried the same thing with a plugin I didn't make myself, it will only load the DLL if it's within a subfolder.