### PR TITLE
Fix vscode build task for NET 8

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -20,6 +20,7 @@
       "type": "shell",
       "args": [
         "publish",
+        "--configuration=Debug",
         "${workspaceFolder}/${config:pluginName}.sln",
         "/property:GenerateFullPaths=true",
         "/consoleloggerparameters:NoSummary"


### PR DESCRIPTION
In .NET 8 and above Debug is not the default publish configuration anymore. See below from `dotnet publish --help`:

```
-c, --configuration <CONFIGURATION>  The configuration to publish for. The default is 'Release' for NET 8.0 projects and above, but 'Debug' for older projects.
```