### PR TITLE
Fixed plugin template to build and copy correctly, allowing settings button to show and the plugin to register.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
             "name": "Launch",
             "request": "launch",
             "preLaunchTask": "build-and-copy",
-            "program": "${config:jellyfinDir}/bin/Debug/net8.0/jellyfin.dll",
+            "program": "${config:jellyfinDir}/bin/Debug/net9.0/jellyfin.dll",
             "args": [
                //"--nowebclient"
                "--webdir",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -60,14 +60,14 @@
       "command": "cp",
       "windows": {
         "args": [
-          "./${config:pluginName}/bin/Debug/net8.0/publish/*",
+          "./${config:pluginName}/bin/Debug/net9.0/publish/*",
           "${config:jellyfinWindowsDataDir}/plugins/${config:pluginName}/"
         ]
       },
       "linux": {
         "args": [
           "-r",
-          "./${config:pluginName}/bin/Debug/net8.0/publish/*",
+          "./${config:pluginName}/bin/Debug/net9.0/publish/*",
           "${config:jellyfinLinuxDataDir}/plugins/${config:pluginName}/"
         ]
       }

--- a/Jellyfin.Plugin.Template/Jellyfin.Plugin.Template.csproj
+++ b/Jellyfin.Plugin.Template/Jellyfin.Plugin.Template.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>Jellyfin.Plugin.Template</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -11,8 +11,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.9.11" />
-    <PackageReference Include="Jellyfin.Model" Version="10.9.11" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.9.11" >
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+    <PackageReference Include="Jellyfin.Model" Version="10.9.11">
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
By adding `<ExcludeAssets>runtime</ExcludeAssets>` to the csproj. The plugin will now correctly register in jellyfin after copy.
Also changed the target framework to net9.0 in line with the other projects.